### PR TITLE
Fix pattern matching when arguments contain '*'

### DIFF
--- a/binstub
+++ b/binstub
@@ -59,7 +59,7 @@ while IFS= read -r line; do
       argument="${arguments[$i]}"
 
       case "$argument" in
-        $pattern ) ;;
+        "$pattern" ) ;;
         * ) result=1 ;;
       esac
     done


### PR DESCRIPTION
#### Because:

* If the arguments string includes an '*' (asterisk) character then the
  bats-mock stub appears to fail to recognise the call.

#### This change:

* Quotes the `$pattern` in the arguments case comparison as this appears
  to resolve the issue.

Fixes #7 