### PR TITLE
Should allow for arguments containing whitespaces to be matched

### DIFF
--- a/binstub
+++ b/binstub
@@ -49,8 +49,8 @@ while IFS= read -r line; do
     # respecting quoting.
     set -f
     patterns=($patterns)
+    arguments=($@)
     set +f
-    arguments=("$@")
 
     # Match the expected argument patterns to actual
     # arguments.


### PR DESCRIPTION
This would allow for stubbing commands with whitespace in its arguments, even if it is not an elegant solution.