### PR TITLE
Redirect stdin to the stubbed command to allow users to verify stub inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ Here, we used the `assert_success` and `assert_output` functions from [bats-asse
 
 Once the test case is done, you should call `unstub <program>` in order to clean up the temporary files, and make a final check that all the plans have been met for the stub.
 
+### Verifying stub input
+
+If you want to verify that your stub was passed the correct data in STDIN, you can redirect its content to a temporary file and check it.
+
+```
+@test "send_message" {
+
+	stub curl \
+		"${_CURL_ARGS} : cat > ${_TMP_DIR}/actual-input ; cat ${_RESOURCES_DIR}/mock-output"
+	
+	run send_message
+	assert_success
+	diff "${_TMP_DIR}/actual-input" "${_RESOURCES_DIR}/expected-input"
+}
+```
+
 
 ## How it works
 

--- a/binstub
+++ b/binstub
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+# If stdin comes from a pipe, save its content for later
+if ! [ -t 0 ]; then
+	input="$(cat)"
+fi
 status=0
 program="${0##*/}"
 PROGRAM="$(echo "$program" | tr a-z- A-Z_)"
@@ -19,7 +23,6 @@ fi
 [ -e "${!_STUB_PLAN}" ] || exit 1
 [ -n "${!_STUB_RUN}" ] || eval "${_STUB_RUN}"="${BATS_MOCK_TMPDIR}/${program}-stub-run"
 
-
 # Initialize or load the stub run information.
 eval "${_STUB_INDEX}"=1
 eval "${_STUB_RESULT}"=0
@@ -30,6 +33,8 @@ eval "${_STUB_RESULT}"=0
 index=0
 while IFS= read -r line; do
   index=$(($index + 1))
+
+
 
   if [ -z "${!_STUB_END}" ] && [ $index -eq "${!_STUB_INDEX}" ]; then
     # We found the plan line we're interested in.
@@ -51,6 +56,7 @@ while IFS= read -r line; do
     patterns=($patterns)
     set +f
     arguments=("$@")
+    
 
     # Match the expected argument patterns to actual
     # arguments.
@@ -68,7 +74,7 @@ while IFS= read -r line; do
     # in a subshell. Otherwise, log the failure.
     if [ $result -eq 0 ] ; then
       set +e
-      ( eval "$command" )
+      ( eval "$command"  <<< "$input" )
       status="$?"
       set -e
     else
@@ -79,6 +85,7 @@ done < "${!_STUB_PLAN}"
 
 
 if [ -n "${!_STUB_END}" ]; then
+
   # Clean up the run file.
   rm -f "${!_STUB_RUN}"
 
@@ -90,7 +97,6 @@ if [ -n "${!_STUB_END}" ]; then
 
   # Return the result.
   exit "${!_STUB_RESULT}"
-
 else
   # If the requested index is larger than the number
   # of lines in the plan file, we failed.
@@ -104,5 +110,4 @@ else
   } > "${!_STUB_RUN}"
 
   exit "$status"
-
 fi


### PR DESCRIPTION
This PR adds a feature that I needed for my tests.

Basically, we save the content of stdin early in the binstub process to be able to redirect it to the stub command. This way, we can verify what input was given to our stub.

STDIN is only read if it is not a tty, or test will wait forever for some user input.