### PR TITLE
Improve matching of complex parameters

### DIFF
--- a/binstub
+++ b/binstub
@@ -59,7 +59,7 @@ while IFS= read -r line; do
       argument="${arguments[$i]}"
 
       case "$argument" in
-        $pattern ) ;;
+        "$pattern" ) ;;
         * ) result=1 ;;
       esac
     done


### PR DESCRIPTION
I was having a matching issue, as I was attempting to stub curl with an inline data parameter.

```
pattern : {"environments":[{"sys":{"id":"master","type":"Link","linkType":"Environment"}},{"sys":{"id":"testenv","type":"Link","linkType":"Environment"}}]}
argument: {"environments":[{"sys":{"id":"master","type":"Link","linkType":"Environment"}},{"sys":{"id":"testenv","type":"Link","linkType":"Environment"}}]}
result: 1
```

Quoting the $pattern variable fixed the issue for me.