### PR TITLE
Show unexpected and missing calls

### DIFF
--- a/binstub
+++ b/binstub
@@ -11,6 +11,7 @@ _STUB_INDEX="${PROGRAM}_STUB_INDEX"
 _STUB_RESULT="${PROGRAM}_STUB_RESULT"
 _STUB_END="${PROGRAM}_STUB_END"
 _STUB_DEBUG="${PROGRAM}_STUB_DEBUG"
+_STUB_ERRORS="${PROGRAM}_STUB_ERRORS"
 
 if [ -n "${!_STUB_DEBUG}" ]; then
   echo "$program" "$@" >&${!_STUB_DEBUG}
@@ -25,24 +26,31 @@ eval "${_STUB_INDEX}"=1
 eval "${_STUB_RESULT}"=0
 [ ! -e "${!_STUB_RUN}" ] || source "${!_STUB_RUN}"
 
+function _stub_split_pattern_line {
+  # Split the line into an array of arguments to
+  # match and a command to run to produce output.
+  command=" $1"
+  if [ "$command" != "${command/ : }" ]; then
+    patterns="${command%% : *}"
+    command="${command#* : }"
+  else
+    patterns=""
+    command="$1"
+  fi
+}
 
 # Loop over each line in the plan.
 index=0
+match_found=0
 while IFS= read -r line; do
-  index=$(($index + 1))
+  index=$((index + 1))
 
   if [ -z "${!_STUB_END}" ] && [ $index -eq "${!_STUB_INDEX}" ]; then
     # We found the plan line we're interested in.
     # Start off by assuming success.
-    result=0
+    match_found=1
 
-    # Split the line into an array of arguments to
-    # match and a command to run to produce output.
-    command=" $line"
-    if [ "$command" != "${command/ : }" ]; then
-      patterns="${command%% : *}"
-      command="${command#* : }"
-    fi
+    _stub_split_pattern_line "$line"
 
     # Naively split patterns by whitespace for now.
     # In the future, use a sed script to split while
@@ -60,13 +68,13 @@ while IFS= read -r line; do
 
       case "$argument" in
         $pattern ) ;;
-        * ) result=1 ;;
+        * ) match_found=0 ;;
       esac
     done
 
     # If the arguments matched, evaluate the command
     # in a subshell. Otherwise, log the failure.
-    if [ $result -eq 0 ] ; then
+    if [ $match_found -eq 1 ] ; then
       set +e
       ( eval "$command" )
       status="$?"
@@ -86,6 +94,20 @@ if [ -n "${!_STUB_END}" ]; then
   # the requested index, we failed.
   if [ $index -ge "${!_STUB_INDEX}" ]; then
     eval "${_STUB_RESULT}"=1
+    while IFS= read -r line; do
+      index=$((index + 1))
+
+      if [ $index -ge "${!_STUB_INDEX}" ]; then
+        _stub_split_pattern_line "$line"
+        echo "Missing call: \`$program $patterns\`"
+      fi
+    done < "${!_STUB_PLAN}"
+  fi
+  if [ -f "${!_STUB_ERRORS}" ]; then
+    while IFS= read -r line; do
+      echo "Unexpected call: \`$program $line\`"
+    done < "${!_STUB_ERRORS}"
+    rm "${!_STUB_ERRORS}"
   fi
 
   # Return the result.
@@ -94,8 +116,9 @@ if [ -n "${!_STUB_END}" ]; then
 else
   # If the requested index is larger than the number
   # of lines in the plan file, we failed.
-  if [ "${!_STUB_INDEX}" -gt $index ]; then
+  if [ $match_found -eq 0 ]; then
     eval "${_STUB_RESULT}"=1
+    printf '%s\n' "$*" >> "${!_STUB_ERRORS}"
   fi
 
   # Write out the run information.

--- a/stub.bash
+++ b/stub.bash
@@ -10,6 +10,7 @@ stub() {
 
   export "${prefix}_STUB_PLAN"="${BATS_MOCK_TMPDIR}/${program}-stub-plan"
   export "${prefix}_STUB_RUN"="${BATS_MOCK_TMPDIR}/${program}-stub-run"
+  export "${prefix}_STUB_ERRORS"="${BATS_MOCK_TMPDIR}/${program}-stub-errors"
   export "${prefix}_STUB_END"=
 
   mkdir -p "${BATS_MOCK_BINDIR}"
@@ -30,6 +31,6 @@ unstub() {
   "$path" || STATUS="$?"
 
   rm -f "$path"
-  rm -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run"
+  rm -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run" "${BATS_MOCK_TMPDIR}/${program}-stub-errors"
   return "$STATUS"
 }


### PR DESCRIPTION
Closes #19

Use a special file `${program}-stub-errors` to record unexpected calls and show them together with missing invocations on `unstub`