### PR TITLE
support to omit validation of stub-invocations during unstub

### DIFF
--- a/stub.bash
+++ b/stub.bash
@@ -31,7 +31,9 @@ unstub() {
   export "${prefix}_STUB_END"=1
 
   local STATUS=0
-  "$path" || STATUS="$?"
+  if [ ${_STUB_OMIT_VALIDATION:-0} -le 0 ]; then
+    "$path" || STATUS="$?"
+  fi
 
   rm -f "$path"
   rm -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run"


### PR DESCRIPTION
Allow to only stub a program but not fail tests if parameters don't match.