### PR TITLE
inspect args

### DIFF
--- a/binstub
+++ b/binstub
@@ -26,6 +26,21 @@ eval "${_STUB_INDEX}"=1
 eval "${_STUB_RESULT}"=0
 [ ! -e "${!_STUB_RUN}" ] || source "${!_STUB_RUN}"
 
+# Expose this for stub scripts.
+inspect_args() {
+  local arg
+  local sep=''
+  for arg; do
+    if [[ $arg == *' '* ]]; then
+      printf '%s"%s"' "$sep" "${arg//\"/\\\"}"
+    elif [[ $arg == *'"'* ]]; then
+      printf "%s'%s'" "$sep" "$arg"
+    else
+      printf '%s%s' "$sep" "$arg"
+    fi
+    sep=" "
+  done
+}
 
 # Loop over each line in the plan.
 index=0

--- a/binstub
+++ b/binstub
@@ -43,8 +43,9 @@ inspect_args() {
 }
 
 # Loop over each line in the plan.
+IFS=$'\n' read -d '' -r -a lines < "${!_STUB_PLAN}" || true
 index=0
-while IFS= read -r line; do
+for line in "${lines[@]}"; do
   index=$(($index + 1))
 
   if [[ -z "${!_STUB_END}" && -n "${!_STUB_NOINDEX}" || $index -eq "${!_STUB_INDEX}" ]]; then
@@ -92,7 +93,7 @@ while IFS= read -r line; do
       eval "${_STUB_RESULT}"=1
     fi
   fi
-done < "${!_STUB_PLAN}"
+done
 
 
 if [ -n "${!_STUB_END}" ]; then


### PR DESCRIPTION
Adds `inspect_args` function to the stub that stubs can then use to fully
print and assert against their arguments from https://github.com/rbenv/ruby-build/commit/6b6fa457a0bb2e2966e1460f7119cdd73e305600

Backports fixes from https://github.com/rbenv/ruby-build/commit/31e53468b65fd3f881bd4ba07b5f0131e1663971

closes #38 completely