### PR TITLE
feat: allow a forced unstub mode without plans validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Finally, when the stub is removed with `unstub`,
 there is a final check to ensure there are no remaining un-met plans
 (which would indicated an expected invocation that did not occur).
 
+You can force to `unstub` without validation of expected plans with
+`unstub <cmd> true`.
+
 ### Unstubbing
 
 Once the test case is done,

--- a/stub.bash
+++ b/stub.bash
@@ -32,6 +32,7 @@ stub_repeated() {
 
 unstub() {
   local program="$1"
+  local force="${2:-false}"
   local prefix
   prefix="$(echo "$program" | tr a-z- A-Z_)"
   local path="${BATS_MOCK_BINDIR}/${program}"
@@ -39,7 +40,9 @@ unstub() {
   export "${prefix}_STUB_END"=1
 
   local STATUS=0
-  "$path" || STATUS="$?"
+  if [ "$force" != 'true' ]; then
+    "$path" || STATUS="$?"
+  fi
 
   rm -f "$path"
   rm -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run"

--- a/test/stub.bats
+++ b/test/stub.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+# this is the "code under test"
+# it would normally be in another file
+format_date() {
+  date -r 222
+}
+
+setup() {
+  load '../load'
+  _DATE_ARGS='-r 222'
+}
+
+@test "date format util formats date with expected arguments" {
+  stub date \
+      "${_DATE_ARGS} : echo 'I am stubbed!'" \
+      "${_DATE_ARGS} : echo 'Wed Dec 31 18:03:42 CST 1969'"
+
+  result="$(format_date)"
+  [ "$result" == 'I am stubbed!' ]
+
+  result="$(format_date)"
+  [ "$result" == 'Wed Dec 31 18:03:42 CST 1969' ]
+
+  unstub date
+}
+
+@test "unstub forced not enough invocations" {
+  stub date \
+      "${_DATE_ARGS} : echo 'I am stubbed!'" \
+      "${_DATE_ARGS} : echo 'Wed Dec 31 18:03:42 CST 1969'"
+
+  result="$(format_date)"
+  [ "$result" == 'I am stubbed!' ]
+
+  unstub date true
+}


### PR DESCRIPTION
Introduce the ability to "force" an *unstub* without verficiation of the stub plans. The idea is to not fail if some invocations are delcared for the stubbed command but not used.

It adds a new parameter to the `unstub` function: `unstub <cmd> [forced=false]`.
The default behaviour is to keep the validation and fail if some plans were not called.

---

Dependencies before to merge:

* [ ] #48 merged